### PR TITLE
Abstract: Fix case where only one keyword exists

### DIFF
--- a/lib/pages/abstract.typ
+++ b/lib/pages/abstract.typ
@@ -25,7 +25,11 @@
 
     custom_title(if language == "en" { "Keywords" } else { "Stichworte" }),
     v(6mm),
-    text(keywords.join(", ")),
+    if type(keywords) == array {
+      text(keywords.join(", "))
+    } else {
+      text(keywords)
+    },
 
     v(9mm),
 


### PR DESCRIPTION
If you only have one keyword the typst template refuses to compile as `("blabla")` does not get parsed as an array by default but counts as a string. Only `("blabla", "blublu")` would properly compile. Thus I added a simple backup strategy of showcasing the string itself, which fixes the methods. 

World Peace :)