### PR TITLE
make toc, lof, lot, listings sections configurable

### DIFF
--- a/lib/lib.typ
+++ b/lib/lib.typ
@@ -39,6 +39,11 @@
     before-content: before-content,
     after-content: after-content,
     body,
+
+    table-of-contents: true,
+    list-of-figures: false,
+    list-of-tables: false,
+    listings: false,
   )
 }
 
@@ -80,6 +85,11 @@
     before-content: before-content,
     after-content: after-content,
     body,
+
+    table-of-contents: true,
+    list-of-figures: false,
+    list-of-tables: false,
+    listings: false,
   )
 }
 
@@ -126,6 +136,11 @@
     before-content: before-content,
     after-content: after-content,
     body,
+
+    table-of-contents: true,
+    list-of-figures: true,
+    list-of-tables: true,
+    listings: true,
   )
 }
 
@@ -172,5 +187,10 @@
     before-content: before-content,
     after-content: after-content,
     body,
+
+    table-of-contents: true,
+    list-of-figures: true,
+    list-of-tables: true,
+    listings: true,
   )
 }

--- a/lib/template.typ
+++ b/lib/template.typ
@@ -23,6 +23,11 @@
   before-content: none,
   after-content: none,
   body,
+  // Content
+  table-of-contents: true,
+  list-of-figures: true,
+  list-of-tables: true,
+  listings: true
 ) = {
   let THESIS_HEADING_EXTRA_TOP_MARGIN = 70pt
   let PAGE_MARGIN_TOP = 37mm
@@ -196,20 +201,22 @@
   }
 
   // Table of contents.
-  include "pages/outline.typ"
+  if table-of-contents {
+    include "pages/outline.typ"
+  }
 
   // List of Figures
-  if is-thesis {
+  if list-of-figures {
     include "pages/list_of_figures.typ"
   }
 
   // List of Tables
-  if is-thesis {
+  if list-of-tables {
     include "pages/list_of_tables.typ"
   }
 
   // Listings
-  if is-thesis {
+  if listings {
     include "pages/listings.typ"
   }
 


### PR DESCRIPTION
whether the document includes the toc, lof, lot, listings was previously tied to the type of document. this adds parameters for these section, so they can be switched on/off easily. the newly introduced variables keep the same defaults per document type as before.